### PR TITLE
Fixed bug with double tensoring the initial state.

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ for i_episode in itertools.count():
                                                                                 np.round(np.mean(rewards[-100:]),2)))
 
     if i_episode % 10 == 0 and args.eval == True:
-        state = torch.Tensor([env.reset()])
+        state = env.reset()
         episode_reward = 0
         while True:
             action = agent.select_action(state, eval=True)


### PR DESCRIPTION
Hi, I tried running your code for MountainCarContinuous-v0 environment and got an error because of wrong shapes. It's because you convert the numpy array into a tensor twice (only for the very first eval state).
This should fix it :)