### PR TITLE
Fix bugs of action re-scaling

### DIFF
--- a/model.py
+++ b/model.py
@@ -96,10 +96,11 @@ class GaussianPolicy(nn.Module):
         std = log_std.exp()
         normal = Normal(mean, std)
         x_t = normal.rsample()  # for reparameterization trick (mean + std * N(0,1))
-        action = torch.tanh(x_t) * self.action_scale + self.action_bias
+        y_t = torch.tanh(x_t)
+        action = y_t * self.action_scale + self.action_bias
         log_prob = normal.log_prob(x_t)
         # Enforcing Action Bound
-        log_prob -= torch.log(self.action_scale * (1 - action.pow(2)) + epsilon)
+        log_prob -= torch.log(self.action_scale * (1 - y_t.pow(2)) + epsilon)
         log_prob = log_prob.sum(1, keepdim=True)
         return action, log_prob, torch.tanh(mean)
 


### PR DESCRIPTION
Sorry for my misunderstanding.

I think the reason of degrading performance with action re-scaling is wrong calculations of log likelihood.
Because re-scaling changes the likelihood, it need to be fixed correctly.

I think now it's correctly fixed, although I haven't checked (I have no computational resource available...)
Can you test it?

Anyway, I really appreciate your great work.