### PR TITLE
Fix error with DeterministicPolicy

### DIFF
--- a/model.py
+++ b/model.py
@@ -148,4 +148,5 @@ class DeterministicPolicy(nn.Module):
     def to(self, device):
         self.action_scale = self.action_scale.to(device)
         self.action_bias = self.action_bias.to(device)
-        return super(GaussianPolicy, self).to(device)
+        self.noise = self.noise.to(device)
+        return super(DeterministicPolicy, self).to(device)


### PR DESCRIPTION
More pytorch-native way would be to use `Module.register_buffer()` method. In that case, buffer won't be used in parameters(), but will be converted to CUDA and CPU with `to()` call transparently.